### PR TITLE
New kernel, sound modules, DSP firmware and RTL8192E WiFi module

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ This repo contains all files, used by the Volumio Builder to create a **sparky**
 - 20161013: Added more wifi drivers
 - 20161013: Added missing Atheros ath09-htc
             removed IP tunneling
+- 20161013: Compiled from the Allo kernel github
+            added WiFi module RTL8192E, correct piano and piano2.1 sound modules
+	    added dsp-firmware as a separate folder to be used during image build 
 
-
+	    
 
  
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ This repo contains all files, used by the Volumio Builder to create a **sparky**
             removed IP tunneling
 - 20161013: Compiled from the Allo kernel github
             added WiFi module RTL8192E, correct piano and piano2.1 sound modules
-	    added dsp-firmware as a separate folder to be used during image build 
 
 	    
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ This repo contains all files, used by the Volumio Builder to create a **sparky**
 - Initial 20160922: Full Volumio 2 support on kernel 3.10.37 with backported overlayfs
 - 20160926: Added drvers for pcm5242 (piano 2/ piano 2.1 support)
 - 20161013: Added more wifi drivers
+- 20161013: Added missing Atheros ath09-htc
+            removed IP tunneling
+
+
 
  
 


### PR DESCRIPTION
sparky build scripts will follow, you need both!

I tested piano 2.1, therefore I put snd-soc-allo-piano-dac-plus in  /etc/modules.
For piano 2.0 you need to load snd-allo-piano-dac!
I presume this needs to be configurable, have not tried to add both...